### PR TITLE
fix(frontend): removed 'user-info' class in custom.scss

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,6 +1,5 @@
 const config = {
   verbose: true,
-  errorOnDeprecated: false,
   jest: {
     setupFilesAfterEnv: ["src/setupTests.js"],
   },

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,5 +1,6 @@
 const config = {
   verbose: true,
+  errorOnDeprecated: false,
   jest: {
     setupFilesAfterEnv: ["src/setupTests.js"],
   },

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -27,6 +27,7 @@ body {
   background-position: top;
   background-repeat: no-repeat;
 }
+
 .page {
   margin-top: 2 * $spacer;
   margin-bottom: 2 * $spacer;
@@ -54,8 +55,4 @@ body {
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-box-orient: vertical;
-}
-
-.user-info {
-  min-width: 800px;
 }

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -27,7 +27,6 @@ body {
   background-position: top;
   background-repeat: no-repeat;
 }
-
 .page {
   margin-top: 2 * $spacer;
   margin-bottom: 2 * $spacer;
@@ -55,4 +54,8 @@ body {
   text-overflow: ellipsis;
   display: -webkit-box;
   -webkit-box-orient: vertical;
+}
+
+.user-info {
+  min-width: 800px;
 }


### PR DESCRIPTION
The 'user-info' class in frontend/custom.scss had a property 'min-width: 800px' due to that all the mobile users was having a problem where they couldn't see user's avatar and follow button on his profile page. As it is not important, removed it.